### PR TITLE
Feature/display processed plans

### DIFF
--- a/backend/app/api/export_routes.py
+++ b/backend/app/api/export_routes.py
@@ -14,7 +14,9 @@ router = APIRouter()
 @router.post("/export/preview", summary="החזרת GeoJSON לתצוגה מקדימה")
 async def export_preview(plans: list[dict]) -> dict:
     gdf = build_gdf_from_plans(plans)
+    gdf = gdf.to_crs("EPSG:4326")
     geojson = create_geojson_preview(gdf)
+
     return geojson
 
 

--- a/backend/app/services/mavat_scraper.py
+++ b/backend/app/services/mavat_scraper.py
@@ -32,7 +32,7 @@ def extract_main_fields_sync(plan: dict) -> dict:
     if not url:
         return plan
 
-    print("🔗 Trying to open (Selenium):", url)
+    # print("🔗 Trying to open (Selenium):", url)
 
     chrome_options = webdriver.ChromeOptions()
     chrome_options.add_argument("--headless")

--- a/frontend/react/package-lock.json
+++ b/frontend/react/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.6",
+        "leaflet": "^1.9.4",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-leaflet": "^5.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -1032,6 +1034,17 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3036,6 +3049,12 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -3791,6 +3810,20 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "node_modules/react-refresh": {

--- a/frontend/react/package.json
+++ b/frontend/react/package.json
@@ -11,8 +11,10 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.6",
+    "leaflet": "^1.9.4",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-leaflet": "^5.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/frontend/react/src/App.jsx
+++ b/frontend/react/src/App.jsx
@@ -1,14 +1,38 @@
+import { useState } from "react";
 import "./App.css";
 import PlansMap from "./components/PlansMap";
+import PlansTable from "./components/PlansTable";
 import PolygonUploader from "./components/PolygonUploader";
-import { exampleGeojson } from "./components/example.geojson";
 
 function App() {
+  const [plansGeojson, setPlansGeojson] = useState(null);
+
+  const handlePlansReady = async (plans) => {
+    fetch("http://localhost:8000/export/preview", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(plans), // נוודא שפה יש את הנתונים הנכונים
+    })
+      .then((res) => res.json())
+      .then((geojson) => {
+        if (!geojson.features || geojson.features.length === 0) {
+          console.error("❌ No valid features in the GeoJSON!");
+          return;
+        }
+        setPlansGeojson(geojson);
+      })
+      .catch((err) => console.error("❌ Error fetching GeoJSON:", err));
+  };
+
   return (
     <>
-      {/* <PolygonUploader key="upload" /> */}
-      <h1 className="text-xl font-bold mb-4">תצוגת תכניות לדוגמה</h1>
-      <PlansMap data={exampleGeojson} />
+      <PolygonUploader onPlansReady={handlePlansReady} />
+      {plansGeojson && (
+        <>
+          <PlansMap data={plansGeojson} />
+          <PlansTable data={plansGeojson} />
+        </>
+      )}
     </>
   );
 }

--- a/frontend/react/src/App.jsx
+++ b/frontend/react/src/App.jsx
@@ -1,10 +1,14 @@
 import "./App.css";
+import PlansMap from "./components/PlansMap";
 import PolygonUploader from "./components/PolygonUploader";
+import { exampleGeojson } from "./components/example.geojson";
 
 function App() {
   return (
     <>
-      <PolygonUploader key="upload" />
+      {/* <PolygonUploader key="upload" /> */}
+      <h1 className="text-xl font-bold mb-4">תצוגת תכניות לדוגמה</h1>
+      <PlansMap data={exampleGeojson} />
     </>
   );
 }

--- a/frontend/react/src/App.jsx
+++ b/frontend/react/src/App.jsx
@@ -6,6 +6,7 @@ import PolygonUploader from "./components/PolygonUploader";
 
 function App() {
   const [plansGeojson, setPlansGeojson] = useState(null);
+  const [hoveredPlanId, setHoveredPlanId] = useState(null);
 
   const handlePlansReady = async (plans) => {
     fetch("http://localhost:8000/export/preview", {
@@ -29,8 +30,8 @@ function App() {
       <PolygonUploader onPlansReady={handlePlansReady} />
       {plansGeojson && (
         <>
-          <PlansMap data={plansGeojson} />
-          <PlansTable data={plansGeojson} />
+          <PlansMap data={plansGeojson} hoveredId={hoveredPlanId} />
+          <PlansTable data={plansGeojson} setHoveredId={setHoveredPlanId} />
         </>
       )}
     </>

--- a/frontend/react/src/components/PlansMap.jsx
+++ b/frontend/react/src/components/PlansMap.jsx
@@ -29,7 +29,7 @@ const onEachFeature = (feature, layer) => {
 
 const PlansMap = ({ data }) => {
   return (
-    <div className="h-[500px] w-full rounded-xl overflow-hidden">
+    <div className="w-full max-w-screen-xl mx-auto h-[500px] rounded-xl overflow-hidden">
       <MapContainer
         center={[32.08, 34.78]}
         zoom={12}

--- a/frontend/react/src/components/PlansMap.jsx
+++ b/frontend/react/src/components/PlansMap.jsx
@@ -27,7 +27,7 @@ const onEachFeature = (feature, layer) => {
   layer.bindPopup(popupContent);
 };
 
-const PlansMap = ({ data }) => {
+const PlansMap = ({ data, hoveredId }) => {
   return (
     <div className="w-full max-w-screen-xl mx-auto h-[500px] rounded-xl overflow-hidden">
       <MapContainer
@@ -40,7 +40,15 @@ const PlansMap = ({ data }) => {
           attribution='&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
-        <GeoJSON data={data} onEachFeature={onEachFeature} />
+        <GeoJSON
+          data={data}
+          style={(feature) => ({
+            color: feature.id === hoveredId ? "#0033cc" : "#3388ff",
+            weight: feature.id === hoveredId ? 3 : 1,
+            fillOpacity: 0.5,
+          })}
+          onEachFeature={onEachFeature}
+        />
         <FitBounds data={data} />
       </MapContainer>
     </div>

--- a/frontend/react/src/components/PlansMap.jsx
+++ b/frontend/react/src/components/PlansMap.jsx
@@ -1,0 +1,50 @@
+import { MapContainer, TileLayer, GeoJSON, useMap } from "react-leaflet";
+import "leaflet/dist/leaflet.css";
+import L from "leaflet";
+import { useEffect } from "react";
+
+const FitBounds = ({ data }) => {
+  const map = useMap();
+
+  useEffect(() => {
+    const geoJsonLayer = L.geoJSON(data);
+    const bounds = geoJsonLayer.getBounds();
+    if (bounds.isValid()) {
+      map.fitBounds(bounds);
+    }
+  }, [data, map]);
+
+  return null;
+};
+
+const onEachFeature = (feature, layer) => {
+  const { pl_number, pl_name, station_desc } = feature.properties || {};
+  const popupContent = `
+    <strong>${pl_number || "ללא מספר"}</strong><br/>
+    ${pl_name || "ללא שם"}<br/>
+    <em>${station_desc || ""}</em>
+  `;
+  layer.bindPopup(popupContent);
+};
+
+const PlansMap = ({ data }) => {
+  return (
+    <div className="h-[500px] w-full rounded-xl overflow-hidden">
+      <MapContainer
+        center={[32.08, 34.78]}
+        zoom={12}
+        scrollWheelZoom={true}
+        className="h-full w-full"
+      >
+        <TileLayer
+          attribution='&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        />
+        <GeoJSON data={data} onEachFeature={onEachFeature} />
+        <FitBounds data={data} />
+      </MapContainer>
+    </div>
+  );
+};
+
+export default PlansMap;

--- a/frontend/react/src/components/PlansTable.jsx
+++ b/frontend/react/src/components/PlansTable.jsx
@@ -1,0 +1,73 @@
+const labelToKey = {
+  'סה"כ שטח בדונם': "area_dunam",
+  'מגורים (יח"ד)': "res_units",
+  'מגורים (מ"ר)': "res_sqm",
+  'מסחר (מ"ר)': "com_sqm",
+  'תעסוקה (מ"ר)': "emp_sqm",
+  'מבני ציבור (מ"ר)': "pub_sqm",
+  "חדרי מלון / תיירות (חדר)": "h_rooms",
+  'חדרי מלון / תיירות (מ"ר)': "hotel_sqm",
+  'דירות קטנות (יח"ד)': "small_res",
+  "תחבורה - רק\"ל (מס' תחנות)": "lrt_station_count", // אם קיים
+  'תחבורה - רק"ל (ק"מ)': "lrt_km", // אם קיים
+};
+
+const generalFields = {
+  "מספר תכנית": "pl_number",
+  שם: "pl_name",
+  סטטוס: "status",
+  עיר: "district",
+  "קישור לתכנית": "pl_url",
+};
+
+const PlansTable = ({ data }) => {
+  const headers = {
+    ...generalFields,
+    ...labelToKey,
+  };
+
+  return (
+    <div className="w-full overflow-x-auto mt-6">
+      <div className="min-w-[1000px] mx-auto">
+        <table className="w-full border border-gray-300 text-sm text-right rtl">
+          <thead className="bg-gray-200">
+            <tr>
+              {Object.keys(headers).map((label) => (
+                <th
+                  key={label}
+                  className="p-2 border whitespace-nowrap text-sm text-right"
+                >
+                  {label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {data.features.map((feature, idx) => (
+              <tr key={idx} className="border-t">
+                {Object.values(headers).map((key) => (
+                  <td key={key} className="p-2 border text-center">
+                    {key === "pl_url" && feature.properties[key] ? (
+                      <a
+                        href={feature.properties[key]}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-600 underline"
+                      >
+                        לינק
+                      </a>
+                    ) : (
+                      feature.properties[key] ?? ""
+                    )}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default PlansTable;

--- a/frontend/react/src/components/PlansTable.jsx
+++ b/frontend/react/src/components/PlansTable.jsx
@@ -20,7 +20,7 @@ const generalFields = {
   "קישור לתכנית": "pl_url",
 };
 
-const PlansTable = ({ data }) => {
+const PlansTable = ({ data, setHoveredId }) => {
   const headers = {
     ...generalFields,
     ...labelToKey,
@@ -44,7 +44,12 @@ const PlansTable = ({ data }) => {
           </thead>
           <tbody>
             {data.features.map((feature, idx) => (
-              <tr key={idx} className="border-t">
+              <tr
+                key={idx}
+                onMouseEnter={() => setHoveredId(feature.id)}
+                onMouseLeave={() => setHoveredId(null)}
+                className="border-t cursor-pointer"
+              >
                 {Object.values(headers).map((key) => (
                   <td key={key} className="p-2 border text-center">
                     {key === "pl_url" && feature.properties[key] ? (

--- a/frontend/react/src/components/PolygonUploader.jsx
+++ b/frontend/react/src/components/PolygonUploader.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 
-const PolygonUploader = () => {
+const PolygonUploader = ({ onPlansReady }) => {
   const [file, setFile] = useState(null);
   const [status, setStatus] = useState("idle");
   const [errorMessage, setErrorMessage] = useState(null);
@@ -40,6 +40,10 @@ const PolygonUploader = () => {
       const data = await response.json(); // אם השרת מחזיר JSON
       setServerPlans(data);
       setServerResponse(JSON.stringify(data, null, 2));
+
+      if (onPlansReady) {
+        onPlansReady(data); // ← מעביר את רשימת התוכניות ל־App
+      }
 
       setStatus("success");
     } catch (err) {

--- a/frontend/react/src/components/example.geojson.js
+++ b/frontend/react/src/components/example.geojson.js
@@ -1,0 +1,26 @@
+// example.geojson.js
+export const exampleGeojson = {
+  type: "FeatureCollection",
+  features: [
+    {
+      type: "Feature",
+      properties: {
+        pl_number: "101-000001",
+        pl_name: "תכנית מגורים לדוגמה",
+        station_desc: "אישור",
+      },
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [34.7801, 32.0853],
+            [34.7815, 32.0853],
+            [34.7815, 32.0865],
+            [34.7801, 32.0865],
+            [34.7801, 32.0853],
+          ],
+        ],
+      },
+    },
+  ],
+};

--- a/frontend/react/src/index.css
+++ b/frontend/react/src/index.css
@@ -15,19 +15,9 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-/* a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-} */
-
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
+  /* display: block; */
   min-width: 320px;
   min-height: 100vh;
 }
@@ -37,34 +27,9 @@ h1 {
   line-height: 1.1;
 }
 
-/* button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-} */
-
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;
     background-color: #ffffff;
   }
-  /* a:hover {
-    color: #747bff;
-  } */
-  /* button {
-    background-color: #f9f9f9;
-  } */
 }


### PR DESCRIPTION
## 📥 בקשת משיכה – web-gis-scraper-desktop-electron

### 🧩 תיאור הפיצ'ר
הצגת תוכניות על מפה אינטראקטיבית וטבלת תוצאות לאחר עיבוד נתוני הפוליגון שהועלה.

---

### ✅ מה בוצע
- [x] פיתוח בקובץ: `frontend/react/src/components/PlansMap.jsx` + `PlansTable.jsx` + `App.jsx`
- [x] עדכון מבנה הנתונים המתקבל מהשרת ל־FeatureCollection
- [x] נכתב קובץ תיעוד: `docs/display-processed-plans.md`
- [x] עודכן `development_progress_summary.md` (עודכן אוטומטית על ידי ChatGPT)

---

### 🧪 בדיקות שבוצעו
- [x] הרצה מקומית של השרת (uvicorn)
- [x] שליחת קובץ פוליגון דרך `/upload-polygon`
- [x] בדיקה שהתוצאה מוצגת על המפה עם Popup ו־fitBounds
- [x] בדיקה שהטבלה מציגה שדות מלאים
- [x] בדיקה שהריחוף בטבלה מדגיש את הפוליגון המתאים

---

### 📎 מסמכים נלווים
- תיעוד הפיצ'ר: `docs/display-processed-plans.md`
- שיחה רלוונטית ב־ChatGPT: [קישור לשיחה זו]

---

### ℹ️ הערות חשובות
- התמיכה במיקוד על המפה עובדת רק לאחר המרה ל־EPSG:4326 בצד השרת
- מיפוי השדות בטבלה עודכן לפי `properties` החדשים מהשרת

---

### ⏭️ מה השלב הבא?
שילוב אפשרויות סינון ומיון בטבלה / הדגשה דו-כיוונית בין פוליגון לשורה
